### PR TITLE
hima-common: move libpn547_fw.so to vendor/lib/libpn553_fw.so

### DIFF
--- a/hima-common/hima-common-vendor.mk
+++ b/hima-common/hima-common-vendor.mk
@@ -149,7 +149,7 @@ PRODUCT_COPY_FILES += \
     vendor/htc/hima-common/proprietary/vendor/firmware/keymaster/keymaster.b02:$(TARGET_COPY_OUT_VENDOR)/firmware/keymaster/keymaster.b02 \
     vendor/htc/hima-common/proprietary/vendor/firmware/keymaster/keymaster.b03:$(TARGET_COPY_OUT_VENDOR)/firmware/keymaster/keymaster.b03 \
     vendor/htc/hima-common/proprietary/vendor/firmware/keymaster/keymaster.mdt:$(TARGET_COPY_OUT_VENDOR)/firmware/keymaster/keymaster.mdt \
-    vendor/htc/hima-common/proprietary/vendor/firmware/keymaster/libpn547_fw.so:$(TARGET_COPY_OUT_VENDOR)/firmware/keymaster/libpn547_fw.so \
+    vendor/htc/hima-common/proprietary/vendor/firmware/keymaster/libpn547_fw.so:$(TARGET_COPY_OUT_VENDOR)/lib/libpn553_fw.so \
     vendor/htc/hima-common/proprietary/vendor/firmware/venus.b00:$(TARGET_COPY_OUT_VENDOR)/firmware/venus.b00 \
     vendor/htc/hima-common/proprietary/vendor/firmware/venus.b01:$(TARGET_COPY_OUT_VENDOR)/firmware/venus.b01 \
     vendor/htc/hima-common/proprietary/vendor/firmware/venus.b02:$(TARGET_COPY_OUT_VENDOR)/firmware/venus.b02 \


### PR DESCRIPTION
wrong chip is being detected and config for firmware is ignored.

Change-Id: Ic2914897d7a7f6eb762a1f83a4084fab87c069df